### PR TITLE
o configure.ac:

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 AC_PREREQ([2.59])
 
 # Initialize autoconf.
-AC_INIT([GPTL-fortran], [5.6.0], [james.rosinski@noaa.gov])
+AC_INIT([GPTL-fortran], [5.6.0], [rosinski@ucar.edu])
 
 # Keep libtool macros in an m4 directory.
 AC_CONFIG_MACRO_DIR([m4])
@@ -27,18 +27,6 @@ LT_INIT()
 # Find the Fortran compiler.
 AC_PROG_FC()
 
-# Set HAVE_NANOTIME on x86 systems only.
-AC_MSG_CHECKING([whether x86 nanotime is available])
-AS_CASE([$host], [*86*], [have_nanotime=yes], [have_nanotime=no])
-if test "x$have_nanotime" = xyes; then
-   AC_DEFINE([HAVE_NANOTIME], [1], [x86 nanotime capability is present])
-fi
-AC_MSG_RESULT($have_nanotime)
-
-# Check for papi library.
-AC_CHECK_LIB([papi], [PAPI_library_init], [], [have_papi=no])
-test "x$have_papi" = xno || have_papi=yes
-
 # When built as part of the combined C/Fortran library distribution,
 # the fortran library needs to be built with
 # --enable-package-build. This tells the fortran library where to find
@@ -56,25 +44,28 @@ if test $enable_package_build = no; then
                         [AC_MSG_ERROR([Can't find or link to the GPTL C library.])])
 fi
 
-# Do we have MPI?
+# Do we have MPI? If so, for now just ASSUME it provides a Fortran interface
 AC_CHECK_FUNC([MPI_Init],
-        [AC_DEFINE([HAVE_MPI], [1], [MPI is present])])
-AM_CONDITIONAL([HAVE_MPI], [test "x$ac_cv_func_MPI_Init" = xyes])
-
-# See if the C GPTL was built with PAPI.
-AC_CHECK_FUNC([gptl_papilibraryinit], [c_has_papi=yes], [c_has_papi=no])
-if test $have_papi = yes -a $c_has_papi = no; then
-   AC_MSG_CHECKING([PAPI library is present, but was not built into C library. Turning PAPI off.])
-   have_papi=no
-fi
+        [AC_DEFINE([HAVE_LIBMPI], [1], [MPI is present])])
+AM_CONDITIONAL([HAVE_LIBMPI], [test "x$ac_cv_func_MPI_Init" = xyes])
 
 # Determine the have_papi settings for this build.
-AC_MSG_CHECKING([whether PAPI library is present and should be used])
-AM_CONDITIONAL([HAVE_PAPI], [test "x$have_papi" = xyes])
-if test "x$have_papi" = xyes; then
-   AC_DEFINE([HAVE_PAPI], [1], [PAPI library is present])
+AC_MSG_CHECKING([whether PAPI library support was built into the C library])
+AC_CHECK_FUNC([gptl_papilibraryinit], [c_has_papi=yes], [c_has_papi=no])
+if test "$c_has_papi" = yes; then
+   AC_DEFINE([HAVE_PAPI], [1], [PAPI library support is present])
 fi
-AC_MSG_RESULT($have_papi)
+AC_MSG_RESULT($c_has_papi)
+AM_CONDITIONAL([HAVE_PAPI], [test "$c_has_papi" = yes])
+
+# See if the C GPTL was built with ENABLE_PMPI, and set it here in accordance
+AC_MSG_CHECKING([whether ENABLE_PMPI was set in the C library build])
+AC_CHECK_FUNC([MPI_Send], [c_enabled_pmpi=yes], [c_enabled_pmpi=no])
+if test $c_enabled_pmpi = yes; then
+   AC_DEFINE([ENABLE_PMPI], [1], [--enable-pmpi was specified in the C library build])
+fi
+AC_MSG_RESULT($have_pmpi)
+AM_CONDITIONAL([ENABLE_PMPI], [test "c$enabled_pmpi" = xyes])
 
 # Check for function backtrace_symbols. If HAVE_BACKTRACE=yes will
 # enable auto-generation of function name when auto-profiling and
@@ -88,6 +79,30 @@ if test $have_backtrace = yes; then
    AC_DEFINE([HAVE_BACKTRACE], [1], [backtrace_symbols function is present])
 fi
 AM_CONDITIONAL([HAVE_BACKTRACE], [test "x$have_backtrace" = xyes])
+
+# Need current language to be Fortran to get AC_OPENMP to do the right thing
+AC_LANG_PUSH(Fortran)
+
+# Enable OpenMP support if compiler supports it
+useomp=no;
+AC_OPENMP
+if test "x$ac_cv_prog_c_openmp" != xunsupported; then
+  useomp=yes;
+  AC_DEFINE([THREADED_OMP], [1], [openmp support is present])
+  FCFLAGS="$FCFLAGS $OPENMP_FCFLAGS"
+fi
+AM_CONDITIONAL([HAVE_OPENMP], [test x$useomp = xyes])
+
+# --enable-debug means build with low optimization and add some code inside some #ifdef DEBUG
+AC_ARG_ENABLE([debug], [AS_HELP_STRING([--enable-debug],
+              [enable DEBUG ifdef])])
+test "x$enable_debug" = xyes || enable_debug=no
+if test $enable_debug = yes; then
+   AC_DEFINE([DEBUG], [1], [set debug ifdef])
+   FCFLAGS="$FCFLAGS -O0"
+fi
+
+AC_LANG_POP(Fortran)
 
 dnl # We need the math library for some tests.
 dnl AC_CHECK_LIB([m], [floor], [],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,8 +10,8 @@ if HAVE_PAPI
 libgptlf_la_FCFLAGS += -DHAVE_PAPI
 endif
 
-if HAVE_MPI
-libgptlf_la_FCFLAGS += -DHAVE_MPI
+if HAVE_LIBMPI
+libgptlf_la_FCFLAGS += -DHAVE_LIBMPI
 endif
 
 # This is our output. The GPTL-fortran library.

--- a/src/gptlf.F90
+++ b/src/gptlf.F90
@@ -75,7 +75,7 @@ module gptl
        character(len=*) :: file
      end function gptlpr_file
 
-#ifdef HAVE_MPI
+#ifdef HAVE_LIBMPI
      integer function gptlpr_summary (fcomm)
        integer :: fcomm
      end function gptlpr_summary

--- a/src/gptlf.F90.template
+++ b/src/gptlf.F90.template
@@ -75,7 +75,7 @@ module gptl
        character(len=*) :: file
      end function gptlpr_file
 
-#ifdef HAVE_MPI
+#ifdef HAVE_LIBMPI
      integer function gptlpr_summary (fcomm)
        integer :: fcomm
      end function gptlpr_summary

--- a/src/printmpistatussize.F90
+++ b/src/printmpistatussize.F90
@@ -1,11 +1,11 @@
 program printmpistatussize
-#ifdef HAVE_MPI
+#ifdef HAVE_LIBMPI
   use mpi
 #endif
   implicit none
-#ifdef HAVE_MPI
+#ifdef HAVE_LIBMPI
   write(6,*) 'MPI_STATUS_SIZE=', MPI_STATUS_SIZE
 #else
-  write(6,*) 'Need set HAVE_MPI=yes to get MPI_STATUS_SIZE'
+  write(6,*) 'Need to run configure with something like env FC=mpif90 to get MPI_STATUS_SIZE'
 #endif
 end program printmpistatussize

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -49,11 +49,15 @@ testinit_SOURCES = testinit.F90 ${MODFILE}
 endif
 
 # Extra test for parallel builds. (Does not build yet).
-#if HAVE_MPI
-# check_PROGRAMS += threadohd
-# TESTS += threadohd
-# threadohd_SOURCES = threadohd.F90 ${MODFILE}
-#endif
+if HAVE_LIBMPI
+check_PROGRAMS += pmpi
+TESTS += pmpi
+pmpi_SOURCES = pmpi.F90 ${MODFILE}
+
+check_PROGRAMS += threadohd
+TESTS += threadohd
+threadohd_SOURCES = threadohd.F90 ${MODFILE}
+endif
 
 # Test output to be deleted.
 CLEANFILES = timing.*

--- a/test/pmpi.F90
+++ b/test/pmpi.F90
@@ -49,10 +49,8 @@ program pmpi
   ret = gptlsetoption (gptlabort_on_error, 1)
   ret = gptlsetoption (gptlsync_mpi, 1)
 
-#if ( ! defined HAVE_IARGCGETARG )
   ret = gptlinitialize ()
   ret = gptlstart ("total")
-#endif
 
   call mpi_init (ret)
 
@@ -374,20 +372,8 @@ program pmpi
 !
   call mpi_finalize (ret)
 
-#if ( defined HAVE_IARGCGETARG )
-  if (iam == 0) then
-    write(6,*)'Testing for auto-generated MPI_Init_thru_Finalize region...'
-    ret = gptlquery ('MPI_Init_thru_Finalize', 0, kount, of, wc, usr, sys, pc, 0)
-    if (ret == 0) then
-      write(6,*)'Success'
-    else
-      write(6,*)'Failure'
-    end if
-  end if
-#else
   ret = gptlstop ("total")
   ret = gptlpr (iam)
-#endif
 
   stop 0
 end program pmpi

--- a/test/threadohd.F90
+++ b/test/threadohd.F90
@@ -1,16 +1,9 @@
 program threadohd
-  use mpi
+  use omp_lib
   use gptl
   implicit none
 
   integer :: n, ret, iter
-  integer :: ierr, myrank, nranks
-  real :: arr(48,48)
-  integer, external :: omp_get_max_threads
-
-  call mpi_init (ierr)
-  call mpi_comm_rank (MPI_COMM_WORLD, myrank, ierr)
-  call mpi_comm_size (MPI_COMM_WORLD, nranks, ierr)
 
   ret = gptlsetutr (gptlnanotime)
   ret = gptlinitialize ()
@@ -21,27 +14,22 @@ program threadohd
     do n=1,1000
       ret = gptlstart_threadohd_inner ('loop')
       ret = gptlstart ('base')
-      call sub (myrank)
+      call sub ()
       ret = gptlstop ('base')
       ret = gptlstop_threadohd_inner ('loop')
     end do
     ret = gptlstop_threadohd_outer ('loop')
   end do
 
-  ret = gptlpr (myrank)
-  ret = gptlpr_summary (MPI_COMM_WORLD)
-  call mpi_finalize (ierr)
+  ret = gptlpr (0)
 end program threadohd
 
-subroutine sub(myrank)
+subroutine sub()
+  use omp_lib
   implicit none
-  integer, intent(in) :: myrank
 
   integer :: mythread
-  integer, external :: omp_get_thread_num
 
   mythread = omp_get_thread_num ()
-! No standard way to sleep in Fortran so comment this out
-!  call msleep(myrank+mythread+1)
 end subroutine sub
 


### PR DESCRIPTION
  - Remove unused checks
  - percolate needed settings into test/Makefile.am
  - Add ENABLE_PMPI (and transfer setting from C build)
  - Add test for OpenMP support (required "AC_LANG_PUSH(Fortran)"
  - Add test for --enable-debug
o Change HAVE_MPI to HAVE_LIBMPI for consistency with C lib
o Add tests pmpi and threadohd to test/
o All 9 Fortran tests run via "make check" pass with GNU compiler